### PR TITLE
make work across 2.13 and 2.12 collections

### DIFF
--- a/discovery-consul/src/main/scala/akka/discovery/consul/ConsulServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/akka/discovery/consul/ConsulServiceDiscovery.scala
@@ -57,7 +57,7 @@ class ConsulServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
         )
       }
     } map { targets =>
-      Resolved(name, scala.collection.immutable.Seq(targets: _*))
+      Resolved(name, targets.toList)
     }
   }
 


### PR DESCRIPTION
I think this fixes the travis build error in https://github.com/akka/akka-management/pull/485